### PR TITLE
snap: add adb-support interface

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -30,6 +30,7 @@ apps:
       - raw-usb
       - home
       - network-observe
+      - adb-support
   ramdump:
     command: usr/bin/qdl-ramdump
     plugs:


### PR DESCRIPTION
qdl  depends on udev rules to gain permission to the USB device.

Currently, adb-tools deb packages install udev rules for all known Android devices. Adding adb-support interface will allow qdl to work without sudo, and without installing adb-tools deb separately.